### PR TITLE
AdImage discards url field on create.

### DIFF
--- a/src/FacebookAds/Object/AdImage.php
+++ b/src/FacebookAds/Object/AdImage.php
@@ -144,7 +144,7 @@ class AdImage extends AbstractCrudObject {
     $data = $content['images']
       [basename($this->{AdImageFields::FILENAME})];
 
-    $this->data[AdImageFields::HASH] = $data[AdImageFields::HASH];
+    $this->setDataWithoutValidation($data);
 
     $this->data[static::FIELD_ID]
       = substr($this->getParentId(), 4).':'.$this->data[AdImageFields::HASH];


### PR DESCRIPTION
AdImage create returns the url for the AdImage but the field is discarded by the CrudObject. This just retains that field and any other field that might be present in the payload.

Unfortunately, I'm unable to determine the state of the tests. They are consistently failing for me back to the 2.5.2 tag and I wasn't able to get the integration tests working. Here is some code the reproduces the problem this fixes.

```
$image = new AdImage(null, $account_id);
$image->{AdImageFields::FILENAME} = $config->image_path;
$image->create();

assert($image->{AdImageFields::URL});
```
