### PR TITLE
Fixed bug in the response header's parser

### DIFF
--- a/src/FacebookAds/Http/Adapter/CurlAdapter.php
+++ b/src/FacebookAds/Http/Adapter/CurlAdapter.php
@@ -125,7 +125,7 @@ class CurlAdapter extends AbstractAdapter {
       if (strpos($line, ': ') === false) {
         $headers['http_code'] = $line;
       } else {
-        list ($key, $value) = explode(': ', $line);
+        list ($key, $value) = explode(': ', $line, 2);
         $headers[$key] = $value;
       }
     }


### PR DESCRIPTION
There was incorrect string slicing in case if header's value has symbol ":".
For example header X-FB-Ads-Insights-Throttle: { "app_id_util_pct": 100, "acc_id_util_pct": 10 }
