### PR TITLE
Change method parseHeaders. 

### DIFF
--- a/src/FacebookAds/Http/Adapter/CurlAdapter.php
+++ b/src/FacebookAds/Http/Adapter/CurlAdapter.php
@@ -122,11 +122,12 @@ class CurlAdapter extends AbstractAdapter {
 
     $header_components = explode("\n", $raw_headers);
     foreach ($header_components as $line) {
-      if (strpos($line, ': ') === false) {
+      if (($delimeterPos = strpos($line, ': ')) === false) {
         $headers['http_code'] = $line;
       } else {
-        list ($key, $value) = explode(': ', $line);
-        $headers[$key] = $value;
+        $key = substr($line, 0, $delimeterPos);
+        $value = substr($line, $delimeterPos + 1, strlen($line));
+        $headers[$key] = trim($value);
       }
     }
   }


### PR DESCRIPTION
If value in header have json object(e.c {"app_id_util_pct": 0.00,"acc_id_util_pct": 0.00}), then parsing is incorrect.