### PR TITLE
fixed unhandled case when json_decode leaves field undecoded

### DIFF
--- a/src/FacebookAds/Http/Exception/RequestException.php
+++ b/src/FacebookAds/Http/Exception/RequestException.php
@@ -114,6 +114,10 @@ class RequestException extends Exception {
     }
     $error_data = static::idx($response_data, 'error', array());
 
+    if (is_string(static::idx($error_data, 'error_data'))) {
+      $error_data["error_data"] = json_decode(stripslashes(static::idx($error_data, 'error_data')), true);
+    }
+
     return array(
       'code' =>
         static::idx($error_data, 'code', static::idx($response_data, 'code')),


### PR DESCRIPTION
Related to issue: https://github.com/facebook/facebook-php-ads-sdk/issues/367

Response for error code = 190 and subcode = 490 is not handled correctly.

Part of the JSON response is not parsed correctly by json_decode.