### PR TITLE
Address syntax error when API returns checkpoint errors

### DIFF
--- a/src/FacebookAds/Http/Exception/RequestException.php
+++ b/src/FacebookAds/Http/Exception/RequestException.php
@@ -92,12 +92,15 @@ class RequestException extends Exception {
   }
 
   /**
-   * @param array $array
+   * @param array|string $array
    * @param string|int $key
    * @param mixed $default
    * @return mixed
    */
-  protected static function idx(array $array, $key, $default = null) {
+  protected static function idx($array, $key, $default = null) {
+    if (is_string($array)) {
+      $array = json_decode($array, true);
+    }
     return array_key_exists($key, $array)
       ? $array[$key]
       : $default;


### PR DESCRIPTION
Hi guys! PHP throws syntax error because API returns string instead of expected array declared in `RequestException::idx()`.

In such case response looks like this:
```json
{
  "error": {
    "message": "Error validating access token: The user is enrolled in a blocking, logged-in checkpoint",
    "type": "OAuthException",
    "code": 190,
    "error_subcode": 490,
    "error_data": "{\"checkpoint_flow_id\":\"1501092823525282\",\"checkpoint_content_id\":\"0\",\"show_native_checkpoints\":\"\",\"prefetch_blocking_checkpoint_metadata\":\"1\"}",
    "fbtrace_id": "EJNtJtC0aRu"
  }
}
```
And error looks like this:

> Argument 1 passed to FacebookAds\Http\Exception\RequestException::idx() must be of the type array, string given, called in /%project-path%/vendor/facebook/php-ads-sdk/src/FacebookAds/Http/Exception/RequestException.php on line 126 and defined

The corresponding code looks like this:

```php
      'error_blame_field_specs' =>
        static::idx(static::idx($error_data, 'error_data', array()),
          'blame_field_specs'),
```
At this moment `error_data` holds a string which is getting passed into `RequestException::idx()` expecting an array and call `array_key_exists()` expecting array too.
Ideal solution would be to make sure that `error_data` API returns an JSON object but as immediate solution we can leverage my fix for SDK.