### PR TITLE
Ad image deletion Fixes #389

### DIFF
--- a/src/FacebookAds/Object/AdImage.php
+++ b/src/FacebookAds/Object/AdImage.php
@@ -247,7 +247,7 @@ class AdImage extends AbstractCrudObject {
    * @return void
    * @throws \Exception
    */
-  public function delete(array $params = array()) {
+  public function deleteSelf(array $params = array()) {
     if (!$this->data[AdImageFields::HASH]) {
       throw new \Exception("AdImage hash is required to delete");
     }
@@ -255,6 +255,6 @@ class AdImage extends AbstractCrudObject {
     $params
       = array_merge($params, array('hash' => $this->data[AdImageFields::HASH]));
 
-    parent::delete($params);
+    parent::deleteSelf($params);
   }
 }


### PR DESCRIPTION
This solution is (compatible with the tutorial proposed here: https://developers.facebook.com/docs/marketing-api/reference/ad-image/v3.0#Deleting ) Fixes #389