### PR TITLE
Validates if curl handle is resource on __destruct()

### DIFF
--- a/src/FacebookAds/Http/Adapter/Curl/AbstractCurl.php
+++ b/src/FacebookAds/Http/Adapter/Curl/AbstractCurl.php
@@ -45,7 +45,7 @@ abstract class AbstractCurl implements CurlInterface {
   }
 
   public function __destruct() {
-    if ($this->handle !== null) {
+    if (is_resource($this->handle)) {
       curl_close($this->handle);
     }
   }


### PR DESCRIPTION
I'm getting this error again (Laravel application):
`ErrorException: curl_close() expects parameter 1 to be resource, integer given in /app/vendor/facebook/php-ads-sdk/src/FacebookAds/Http/Adapter/Curl/AbstractCurl.php:49`

My previous fix for this was removed by mistake i guess: https://github.com/facebook/facebook-php-business-sdk/commit/2c1bc39d6409e2c33fe15725c492b33169bfeaec

Previous PR merged into master: https://github.com/facebook/facebook-php-business-sdk/pull/269