### PR TITLE
Add const for file_url in AdVideoFields

### DIFF
--- a/src/FacebookAds/Object/Fields/AdVideoFields.php
+++ b/src/FacebookAds/Object/Fields/AdVideoFields.php
@@ -35,6 +35,7 @@ class AdVideoFields extends AbstractEnum {
   const DESCRIPTION = 'description';
   const EMBED_HTML = 'embed_html';
   const EMBEDDABLE = 'embeddable';
+  const FILE_URL = 'file_url';
   const FORMAT = 'format';
   const FROM = 'from';
   const ICON = 'icon';


### PR DESCRIPTION
Add const for FILE_URL to AdVideoFields so that a new AdVideo can be created from a URL, following the same style used in the example in the documentation.

For more details, see my comment in this issue
https://github.com/facebook/facebook-php-business-sdk/issues/465