### PR TITLE
Define the http_build_query arg separator.

### DIFF
--- a/src/FacebookAds/Http/Request.php
+++ b/src/FacebookAds/Http/Request.php
@@ -240,7 +240,7 @@ class Request implements RequestInterface {
     return $this->getProtocol().$this->getDomain()
       .'/v'.$this->getGraphVersion().$this->getPath()
       .$delimiter
-      .http_build_query($this->getQueryParams()->export());
+      .http_build_query($this->getQueryParams()->export(), '', '&');
   }
 
   /**

--- a/test/FacebookAdsTest/Http/RequestTest.php
+++ b/test/FacebookAdsTest/Http/RequestTest.php
@@ -182,6 +182,13 @@ class RequestTest extends AbstractUnitTestCase {
     $this->assertFalse($file_params === $clone->getFileParams());
   }
 
+  public function testUrlCustomArgSeparator(){
+      $separator = ini_get('arg_separator.output');
+      ini_set('arg_separator.output', '&amp;');
+      $this->testUrl();
+      ini_set('arg_separator.output', $separator);
+  }
+
   /**
    * @depends testProtocol
    * @depends testDomain


### PR DESCRIPTION
In our code we use custom `arg_separator` which surfaced a need of defining to assure a proper function of the SDK. 