### PR TITLE
Update the minimum php version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ to get an access token.
 
 ## Installation
 
-The Facebook Business SDK requires PHP 5.4 or greater.
+The Facebook Business SDK requires PHP 5.6 or greater.
 
 ### Composer
 


### PR DESCRIPTION
Summary:
This diff is associated with an external, developer-reported bug: https://developers.internmc.facebook.com/support/bugs/2461479930775695/.
Since php 5.4 and 5.5 are no longer supported from 2016, we updated the minimum php version for business SDK from 5.4 to 5.6.

Ref: https://www.php.net/supported-versions.php

Reviewed By: Mxiim

Differential Revision: D18691793

