### PR TITLE
array_key_exists bug fix

### DIFF
--- a/src/FacebookAds/Cursor.php
+++ b/src/FacebookAds/Cursor.php
@@ -270,10 +270,10 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
   protected function createUndirectionalizedRequest() {
     $request = $this->getLastResponse()->getRequest()->createClone();
     $params = $request->getQueryParams();
-    if (array_key_exists('before', $params)) {
+    if (isset($params['before'])) {
       unset($params['before']);
     }
-    if (array_key_exists('after', $params)) {
+    if (isset($params['after'])) {
       unset($params['after']);
     }
 


### PR DESCRIPTION
Summary:
This diff is associated with an external, developer-reported bug: https://developers.internmc.facebook.com/support/bugs/445172219720269/.

In PHP version 7.4, `array_key_exists()` is deprecated with Object.
`Parameters` is `extends ArrayObject`, and `array_key_exists()` is called in `Cursor` with arguments which include instance of `Parameters`. In order to avoid the error, I used `isset()` instead.

Differential Revision: D19253757

