### PR TITLE
Request exception - getErrorData with empty error_data fix

### DIFF
--- a/src/FacebookAds/Http/Exception/RequestException.php
+++ b/src/FacebookAds/Http/Exception/RequestException.php
@@ -134,6 +134,10 @@ class RequestException extends Exception {
         json_decode(stripslashes(static::idx($error_data, 'error_data')), true);
     }
 
+    if (is_null(static::idx($error_data, 'error_data'))) {
+      $error_data["error_data"] = array();
+    }
+
     return array(
       'code' =>
         static::idx($error_data, 'code', static::idx($response_data, 'code')),

--- a/test/FacebookAdsTest/Http/Exception/RequestExceptionTest.php
+++ b/test/FacebookAdsTest/Http/Exception/RequestExceptionTest.php
@@ -79,6 +79,20 @@ class RequestExceptionTest extends AbstractUnitTestCase {
     $this->assertSame('abc123', $e->getFacebookTraceId());
   }
 
+  public function testGetErrorBlameFieldSpecsReturnsNullWithNullErrorData() {
+    $data = array(
+      'error' => array(
+          'error_data' => null,
+      ),
+    );
+
+    $response = new Response();
+    $response->setBody(json_encode($data));
+    $e = new RequestException($response);
+
+    $this->assertNull($e->getErrorBlameFieldSpecs());
+  }
+
   /**
    * @return array
    */


### PR DESCRIPTION
Sometimes we are experiencing some warnings in SDK:
`array_key_exists() expects parameter 2 to be array, null given`

It occurs in `RequestException::idx` method, when field `error_data` in response from your API is set and has `null` value. Thus, first argument of outer `idx` call in `RequestException::144` is also null.

I propose to add fallback for `$error_data['error_data'] === null`. 