### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ To manage the Marketing API, please visit your
 <a href="https://developers.facebook.com/apps/<YOUR APP ID>/dashboard"> App Dashboard </a>
 and add the <b>Marketing API</b> product to your app.
 
-**IMPORTANT**: For security, it is recommended that you turn on 'App Secret
-Proof for Server API calls' in your app's Settings->Advanced page.
+**IMPORTANT**: For security, it is recommended that you turn on 'Require App Secret' in your app's Settings->Advanced page.
 
 ### Obtain An Access Token
 


### PR DESCRIPTION
Replaced "App Secret
Proof for Server API calls" with "Require App Secret" as it was changed in the developers.facebook.com and was difficult to find with the wrong name.