### PR TITLE
Correct Class Namespace to avoid Composer 2.0 autoloading issue

### DIFF
--- a/src/FacebookAds/Object/Fields/Agency.php
+++ b/src/FacebookAds/Object/Fields/Agency.php
@@ -22,7 +22,7 @@
  *
  */
 
-namespace FacebookAds\Object;
+namespace FacebookAds\Object\Fields;
 
 class Agency extends AbstractObject {
 


### PR DESCRIPTION
Bump on this, it's been over 4 years for what is a tiny change. Composer 2.0 will stop autoloading this file, as per their optimised autoloader message:

Deprecation Notice: Class FacebookAds\Object\Agency located in ./vendor/facebook/php-ads-sdk/src/FacebookAds/Object/Fields/Agency.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201

Please can we have an update and/or fix, i.e. merge this PR, or rename the current file to be PSR-4 compatible, considering you support PSR-4.