### PR TITLE
API version bump to 9.0

### DIFF
--- a/src/FacebookAds/ApiConfig.php
+++ b/src/FacebookAds/ApiConfig.php
@@ -23,7 +23,7 @@
  */
 namespace FacebookAds;
 class ApiConfig {
-  const APIVersion = '8.0';
+  const APIVersion = '9.0';
   const SDKVersion = '9.0.0';
   const TYPE_CHECKER_STRICT_MODE = false;
 }


### PR DESCRIPTION
With current 8.0 API Version, a AuthorizationException is thrown.  (#2635) You are calling a deprecated version of the Ads API. Please update to the latest version: v9.0.