### PR TITLE
Update AbstractCrudObject.php to fix for PHP8

### DIFF
--- a/src/FacebookAds/Object/AbstractCrudObject.php
+++ b/src/FacebookAds/Object/AbstractCrudObject.php
@@ -388,7 +388,7 @@ class AbstractCrudObject extends AbstractObject {
   protected function fetchConnection(
     array $fields = array(),
     array $params = array(),
-    $prototype_class,
+    $prototype_class = '',
     $endpoint = null) {
     $fields = implode(',', $fields ?: static::getDefaultReadFields());
     if ($fields) {


### PR DESCRIPTION
In PHP8.0 it is not allowed to have required parameters after optional parameters, so I've made the $prototype_class optional