### PR TITLE
Add  argument $app_ids on multi-key methods

### DIFF
--- a/src/FacebookAds/Object/CustomAudience.php
+++ b/src/FacebookAds/Object/CustomAudience.php
@@ -514,6 +514,7 @@ class CustomAudience extends AbstractCrudObject {
    *
    * @param array $users
    * @param array $types
+   * @param array $app_ids
    * @param bool $is_hashed
    * @param bool $is_normalized
    * @return array
@@ -521,9 +522,10 @@ class CustomAudience extends AbstractCrudObject {
   public function addUsersMultiKey(
     array $users,
     array $types,
+    array $app_ids = array(),
     $is_hashed = false,
     $is_normalized = false) {
-    $params = $this->formatParamsMultiKey($users, $types, $is_hashed, $is_normalized);
+    $params = $this->formatParamsMultiKey($users, $types, $app_ids, $is_hashed, $is_normalized);
     return $this->getApi()->call(
       '/'.$this->assureId().'/users',
       RequestInterface::METHOD_POST,
@@ -536,6 +538,7 @@ class CustomAudience extends AbstractCrudObject {
    *
    * @param array $users
    * @param array $types
+   * @param array $app_ids
    * @param bool $is_hashed
    * @param bool $is_normalized
    * @return array
@@ -543,9 +546,10 @@ class CustomAudience extends AbstractCrudObject {
   public function removeUsersMultiKey(
     array $users,
     array $types,
+    array $app_ids = array(),
     $is_hashed = false,
     $is_normalized = false) {
-    $params = $this->formatParamsMultiKey($users, $types, $is_hashed, $is_normalized);
+    $params = $this->formatParamsMultiKey($users, $types, $app_ids, $is_hashed, $is_normalized);
     return $this->getApi()->call(
       '/'.$this->assureId().'/users',
       RequestInterface::METHOD_DELETE,
@@ -557,6 +561,7 @@ class CustomAudience extends AbstractCrudObject {
    *
    * @param array $users
    * @param array $types
+   * @param array $app_ids
    * @param bool $is_hashed
    * @param bool $is_normalized
    * @return array
@@ -564,6 +569,7 @@ class CustomAudience extends AbstractCrudObject {
   protected function formatParamsMultiKey(
     array $users,
     array $types,
+    array $app_ids = array(),
     $is_hashed = false,
     $is_normalized = false) {
 
@@ -601,6 +607,10 @@ class CustomAudience extends AbstractCrudObject {
       'schema' => $types,
       'data' => $users,
     );
+
+      if (!empty($app_ids)) {
+          $payload['app_ids'] = $app_ids;
+      }
 
     return array('payload' => $payload);
   }


### PR DESCRIPTION
Hi there.

Facebook API `app_ids` parameter is required when using field `APPUID`.

This PR add the missing $app_ids argument.

Regards;


