### PR TITLE
remove trailing comma

### DIFF
--- a/examples/aggregator_onboarding/api.php
+++ b/examples/aggregator_onboarding/api.php
@@ -250,7 +250,7 @@ function create_click_to_messenger_ad(
   $account_id,
   $bmid,
   $ad_message,
-  $page_welcome_message,
+  $page_welcome_message
 ) {
   global $aggregator_access_token, $app_id, $page_id;
   $api = setAccessToken($aggregator_access_token);


### PR DESCRIPTION
this is actually LEGAL as of php 8.0.0, but it causes syntax errors with PHP7.4.x, which is still supported i think?