### PR TITLE
Resolve PHP 8.1 Deprecations

### DIFF
--- a/src/FacebookAds/Cursor.php
+++ b/src/FacebookAds/Cursor.php
@@ -28,6 +28,7 @@ use FacebookAds\Http\RequestInterface;
 use FacebookAds\Http\ResponseInterface;
 use FacebookAds\Http\Util;
 use FacebookAds\Object\AbstractObject;
+use ReturnTypeWillChange;
 
 class Cursor implements \Iterator, \Countable, \arrayaccess {
   /**
@@ -419,6 +420,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
     return $this->indexRight;
   }
 
+  #[ReturnTypeWillChange]
   public function rewind() {
     $this->position = $this->indexLeft;
   }
@@ -438,6 +440,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
   /**
    * @return AbstractObject|bool
    */
+  #[ReturnTypeWillChange]
   public function current() {
     return isset($this->objects[$this->position])
       ? $this->objects[$this->position]
@@ -447,6 +450,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
   /**
    * @return int
    */
+  #[ReturnTypeWillChange]
   public function key() {
     return $this->position;
   }
@@ -468,6 +472,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
     }
   }
 
+  #[ReturnTypeWillChange]
   public function next() {
     if ($this->position == $this->getIndexRight()) {
       if ($this->getUseImplicitFetch()) {
@@ -488,6 +493,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
   /**
    * @return bool
    */
+  #[ReturnTypeWillChange]
   public function valid() {
     return isset($this->objects[$this->position]);
   }
@@ -495,6 +501,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
   /**
    * @return int
    */
+  #[ReturnTypeWillChange]
   public function count() {
     return count($this->objects);
   }
@@ -503,6 +510,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
    * @param mixed $offset
    * @param mixed $value
    */
+  #[ReturnTypeWillChange]
   public function offsetSet($offset, $value) {
     if ($offset === null) {
       $this->objects[] = $value;
@@ -515,6 +523,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
    * @param mixed $offset
    * @return bool
    */
+  #[ReturnTypeWillChange]
   public function offsetExists($offset) {
     return isset($this->objects[$offset]);
   }
@@ -522,6 +531,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
   /**
    * @param mixed $offset
    */
+  #[ReturnTypeWillChange]
   public function offsetUnset($offset) {
     unset($this->objects[$offset]);
   }
@@ -530,6 +540,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
    * @param mixed $offset
    * @return mixed
    */
+  #[ReturnTypeWillChange]
   public function offsetGet($offset) {
     return isset($this->objects[$offset]) ? $this->objects[$offset] : null;
   }

--- a/src/FacebookAds/Object/AbstractCrudObject.php
+++ b/src/FacebookAds/Object/AbstractCrudObject.php
@@ -61,7 +61,7 @@ class AbstractCrudObject extends AbstractObject {
     // two integer connected by an underscore, like "123_456"
 
     $int_id = $id;
-    if (strpos($id, 'act_') === 0) {
+    if ($id !== null && strpos($id, 'act_') === 0) {
       $int_id = substr($id, 4);
     }
     $split_by_underscore = explode('_', (string) $id);

--- a/src/FacebookAds/Object/BusinessDataAPI/CustomData.php
+++ b/src/FacebookAds/Object/BusinessDataAPI/CustomData.php
@@ -193,7 +193,7 @@ class CustomData {
       if (is_array($val)) {
         return true;
       } else {
-        return strlen($val);
+        return strlen((string) $val);
       }
     });
 

--- a/src/FacebookAds/Object/BusinessDataAPI/Event.php
+++ b/src/FacebookAds/Object/BusinessDataAPI/Event.php
@@ -159,7 +159,7 @@ class Event {
         if(is_array($val)) {
           return true;
         } else {
-          return strlen($val);
+          return strlen((string) $val);
         }
       });
 

--- a/src/FacebookAds/Object/ServerSide/AdsPixelSettings.php
+++ b/src/FacebookAds/Object/ServerSide/AdsPixelSettings.php
@@ -29,6 +29,7 @@ use FacebookAds\Http\SimpleRequest;
 use FacebookAds\Exception\Exception;
 
 use ArrayAccess;
+use ReturnTypeWillChange;
 
 class AdsPixelSettings implements ArrayAccess {
 
@@ -151,6 +152,7 @@ class AdsPixelSettings implements ArrayAccess {
    * @param integer $offset Offset
    * @return boolean
    */
+  #[ReturnTypeWillChange]
   public function offsetExists($offset) {
     return isset($this->container[$offset]);
   }
@@ -160,6 +162,7 @@ class AdsPixelSettings implements ArrayAccess {
    * @param integer $offset Offset
    * @return mixed
    */
+  #[ReturnTypeWillChange]
   public function offsetGet($offset) {
     return isset($this->container[$offset]) ? $this->container[$offset] : null;
   }
@@ -170,6 +173,7 @@ class AdsPixelSettings implements ArrayAccess {
    * @param mixed $value Value to be set
    * @return void
    */
+  #[ReturnTypeWillChange]
   public function offsetSet($offset, $value) {
     if (is_null($offset)) {
       $this->container[] = $value;
@@ -183,6 +187,7 @@ class AdsPixelSettings implements ArrayAccess {
    * @param integer $offset Offset
    * @return void
    */
+  #[ReturnTypeWillChange]
   public function offsetUnset($offset) {
     unset($this->container[$offset]);
   }

--- a/src/FacebookAds/Object/ServerSide/Content.php
+++ b/src/FacebookAds/Object/ServerSide/Content.php
@@ -25,6 +25,7 @@
 namespace FacebookAds\Object\ServerSide;
 
 use ArrayAccess;
+use ReturnTypeWillChange;
 
 class Content implements ArrayAccess {
   /**
@@ -205,6 +206,7 @@ class Content implements ArrayAccess {
    * @param integer $offset Offset
    * @return boolean
    */
+  #[ReturnTypeWillChange]
   public function offsetExists($offset) {
     return isset($this->container[$offset]);
   }
@@ -214,6 +216,7 @@ class Content implements ArrayAccess {
    * @param integer $offset Offset
    * @return mixed
    */
+  #[ReturnTypeWillChange]
   public function offsetGet($offset) {
     return isset($this->container[$offset]) ? $this->container[$offset] : null;
   }
@@ -224,6 +227,7 @@ class Content implements ArrayAccess {
    * @param mixed $value Value to be set
    * @return void
    */
+  #[ReturnTypeWillChange]
   public function offsetSet($offset, $value) {
     if (is_null($offset)) {
       $this->container[] = $value;
@@ -237,6 +241,7 @@ class Content implements ArrayAccess {
    * @param integer $offset Offset
    * @return void
    */
+  #[ReturnTypeWillChange]
   public function offsetUnset($offset) {
     unset($this->container[$offset]);
   }

--- a/src/FacebookAds/Object/ServerSide/CustomData.php
+++ b/src/FacebookAds/Object/ServerSide/CustomData.php
@@ -459,7 +459,7 @@ class CustomData implements ArrayAccess {
       if (is_array($val)) {
         return true;
       } else {
-        return strlen($val);
+        return strlen((string) $val);
       }
     });
 

--- a/src/FacebookAds/Object/ServerSide/CustomData.php
+++ b/src/FacebookAds/Object/ServerSide/CustomData.php
@@ -26,7 +26,7 @@ namespace FacebookAds\Object\ServerSide;
 
 use ArrayAccess;
 use InvalidArgumentException;
-
+use ReturnTypeWillChange;
 
 class CustomData implements ArrayAccess {
 
@@ -358,6 +358,7 @@ class CustomData implements ArrayAccess {
    * @param integer $offset Offset
    * @return boolean
    */
+  #[ReturnTypeWillChange]
   public function offsetExists($offset) {
     return isset($this->container[$offset]);
   }
@@ -367,6 +368,7 @@ class CustomData implements ArrayAccess {
    * @param integer $offset Offset
    * @return mixed
    */
+  #[ReturnTypeWillChange]
   public function offsetGet($offset) {
     return isset($this->container[$offset]) ? $this->container[$offset] : null;
   }
@@ -377,6 +379,7 @@ class CustomData implements ArrayAccess {
    * @param mixed $value Value to be set
    * @return void
    */
+  #[ReturnTypeWillChange]
   public function offsetSet($offset, $value) {
     if (is_null($offset)) {
       $this->container[] = $value;
@@ -390,6 +393,7 @@ class CustomData implements ArrayAccess {
    * @param integer $offset Offset
    * @return void
    */
+  #[ReturnTypeWillChange]
   public function offsetUnset($offset) {
     unset($this->container[$offset]);
   }

--- a/src/FacebookAds/Object/ServerSide/Event.php
+++ b/src/FacebookAds/Object/ServerSide/Event.php
@@ -381,7 +381,7 @@ class Event implements ArrayAccess {
       'action_source',
       $this->container['action_source']
     );
-    $normalized_payload = array_filter($normalized_payload, function($val) { if(is_array($val)) { return true; } else { return strlen($val); }});
+    $normalized_payload = array_filter($normalized_payload, function($val) { if(is_array($val)) { return true; } else { return strlen((string) $val); }});
     // Add the opt_out value back in if it was filtered out
     if ($this->getOptOut() === false) {
       $normalized_payload['opt_out'] = $this->getOptOut();

--- a/src/FacebookAds/Object/ServerSide/Event.php
+++ b/src/FacebookAds/Object/ServerSide/Event.php
@@ -25,6 +25,7 @@
 namespace FacebookAds\Object\ServerSide;
 
 use ArrayAccess;
+use ReturnTypeWillChange;
 
 /**
  * Server-Side Event
@@ -322,6 +323,7 @@ class Event implements ArrayAccess {
    * @param integer $offset Offset
    * @return boolean
    */
+  #[ReturnTypeWillChange]
   public function offsetExists($offset) {
     return isset($this->container[$offset]);
   }
@@ -331,6 +333,7 @@ class Event implements ArrayAccess {
    * @param integer $offset Offset
    * @return mixed
    */
+  #[ReturnTypeWillChange]
   public function offsetGet($offset) {
     return isset($this->container[$offset]) ? $this->container[$offset] : null;
   }
@@ -341,6 +344,7 @@ class Event implements ArrayAccess {
    * @param mixed $value Value to be set
    * @return void
    */
+  #[ReturnTypeWillChange]
   public function offsetSet($offset, $value) {
     if (is_null($offset)) {
       $this->container[] = $value;
@@ -354,6 +358,7 @@ class Event implements ArrayAccess {
    * @param integer $offset Offset
    * @return void
    */
+  #[ReturnTypeWillChange]
   public function offsetUnset($offset) {
     unset($this->container[$offset]);
   }

--- a/src/FacebookAds/Object/ServerSide/EventRequest.php
+++ b/src/FacebookAds/Object/ServerSide/EventRequest.php
@@ -28,6 +28,7 @@ use ArrayAccess;
 use FacebookAds\Api;
 use FacebookAds\ApiConfig;
 use FacebookAds\Object\AdsPixel;
+use ReturnTypeWillChange;
 
 /**
  * Conversions API Event Request
@@ -409,6 +410,7 @@ class EventRequest implements ArrayAccess {
    * @param integer $offset Offset
    * @return boolean
    */
+  #[ReturnTypeWillChange]
   public function offsetExists($offset) {
     return isset($this->container[$offset]);
   }
@@ -418,6 +420,7 @@ class EventRequest implements ArrayAccess {
    * @param integer $offset Offset
    * @return mixed
    */
+  #[ReturnTypeWillChange]
   public function offsetGet($offset) {
     return isset($this->container[$offset]) ? $this->container[$offset] : null;
   }
@@ -428,6 +431,7 @@ class EventRequest implements ArrayAccess {
    * @param mixed $value Value to be set
    * @return void
    */
+  #[ReturnTypeWillChange]
   public function offsetSet($offset, $value) {
     if (is_null($offset)) {
       $this->container[] = $value;
@@ -441,6 +445,7 @@ class EventRequest implements ArrayAccess {
    * @param integer $offset Offset
    * @return void
    */
+  #[ReturnTypeWillChange]
   public function offsetUnset($offset) {
     unset($this->container[$offset]);
   }

--- a/src/FacebookAds/Object/ServerSide/EventResponse.php
+++ b/src/FacebookAds/Object/ServerSide/EventResponse.php
@@ -25,6 +25,7 @@
 namespace FacebookAds\Object\ServerSide;
 
 use ArrayAccess;
+use ReturnTypeWillChange;
 
 /**
  * Conversions API event response.
@@ -183,6 +184,7 @@ class EventResponse implements ArrayAccess {
    * @param integer $offset Offset
    * @return boolean
    */
+  #[ReturnTypeWillChange]
   public function offsetExists($offset) {
     return isset($this->container[$offset]);
   }
@@ -192,6 +194,7 @@ class EventResponse implements ArrayAccess {
    * @param integer $offset Offset
    * @return mixed
    */
+  #[ReturnTypeWillChange]
   public function offsetGet($offset) {
     return isset($this->container[$offset]) ? $this->container[$offset] : null;
   }
@@ -202,6 +205,7 @@ class EventResponse implements ArrayAccess {
    * @param mixed $value Value to be set
    * @return void
    */
+  #[ReturnTypeWillChange]
   public function offsetSet($offset, $value) {
     if (is_null($offset)) {
       $this->container[] = $value;
@@ -215,6 +219,7 @@ class EventResponse implements ArrayAccess {
    * @param integer $offset Offset
    * @return void
    */
+  #[ReturnTypeWillChange]
   public function offsetUnset($offset) {
     unset($this->container[$offset]);
   }

--- a/src/FacebookAds/Object/ServerSide/UserData.php
+++ b/src/FacebookAds/Object/ServerSide/UserData.php
@@ -26,6 +26,7 @@ namespace FacebookAds\Object\ServerSide;
 
 use ArrayAccess;
 use InvalidArgumentException;
+use ReturnTypeWillChange;
 
 /**
  * UserData is a set of identifiers Facebook can use for targeted attribution.
@@ -821,6 +822,7 @@ class UserData implements ArrayAccess {
    * @param integer $offset Offset
    * @return boolean
    */
+  #[ReturnTypeWillChange]
   public function offsetExists($offset) {
     return isset($this->container[$offset]);
   }
@@ -830,6 +832,7 @@ class UserData implements ArrayAccess {
    * @param integer $offset Offset
    * @return mixed
    */
+  #[ReturnTypeWillChange]
   public function offsetGet($offset) {
     return isset($this->container[$offset]) ? $this->container[$offset] : null;
   }
@@ -840,6 +843,7 @@ class UserData implements ArrayAccess {
    * @param mixed $value Value to be set
    * @return void
    */
+  #[ReturnTypeWillChange]
   public function offsetSet($offset, $value) {
     if (is_null($offset)) {
       $this->container[] = $value;
@@ -853,6 +857,7 @@ class UserData implements ArrayAccess {
    * @param integer $offset Offset
    * @return void
    */
+  #[ReturnTypeWillChange]
   public function offsetUnset($offset) {
     unset($this->container[$offset]);
   }


### PR DESCRIPTION
This resolves php 8.1 deprecations in a backwards compatible way.

More ideally, return types should be added to function definitions, but this would no longer support PHP 5.6 as described in the README. If the team is open to bumping up version requirements to only include supported PHP versions (7.4+), I can revisit this to add return types instead.