### PR TITLE
Add attribute to prevent deprecated notices in PHP 8.1

### DIFF
--- a/src/FacebookAds/Cursor.php
+++ b/src/FacebookAds/Cursor.php
@@ -419,6 +419,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
     return $this->indexRight;
   }
 
+  #[\ReturnTypeWillChange]
   public function rewind() {
     $this->position = $this->indexLeft;
   }
@@ -438,6 +439,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
   /**
    * @return AbstractObject|bool
    */
+  #[\ReturnTypeWillChange]
   public function current() {
     return isset($this->objects[$this->position])
       ? $this->objects[$this->position]
@@ -447,6 +449,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
   /**
    * @return int
    */
+  #[\ReturnTypeWillChange]
   public function key() {
     return $this->position;
   }
@@ -468,6 +471,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
     }
   }
 
+  #[\ReturnTypeWillChange]
   public function next() {
     if ($this->position == $this->getIndexRight()) {
       if ($this->getUseImplicitFetch()) {
@@ -488,6 +492,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
   /**
    * @return bool
    */
+  #[\ReturnTypeWillChange]
   public function valid() {
     return isset($this->objects[$this->position]);
   }
@@ -495,6 +500,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
   /**
    * @return int
    */
+  #[\ReturnTypeWillChange]
   public function count() {
     return count($this->objects);
   }
@@ -503,6 +509,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
    * @param mixed $offset
    * @param mixed $value
    */
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value) {
     if ($offset === null) {
       $this->objects[] = $value;
@@ -515,6 +522,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
    * @param mixed $offset
    * @return bool
    */
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset) {
     return isset($this->objects[$offset]);
   }
@@ -522,6 +530,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
   /**
    * @param mixed $offset
    */
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset) {
     unset($this->objects[$offset]);
   }
@@ -530,6 +539,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
    * @param mixed $offset
    * @return mixed
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset) {
     return isset($this->objects[$offset]) ? $this->objects[$offset] : null;
   }


### PR DESCRIPTION
`Cursor` is implementing `\Iterator`, `\Countable`, and `\arrayaccess`. These all define methods that have the `#[TentativeType]` attribute. Ideally, these methods would be implemented in `Cursor` with the return types specified. However, this isn't possible while maintaining PHP 5.6 compatibility.

To maintain PHP 5.6 compatibility while getting rid of the deprecated notices when using PHP 8.1, the `#[\ReturnTypeWillChange]` attribute has been added to all the methods implemented in `Cursor` that have the `#[TentativeType]` attribute.

This is a fully backwards compatible change.