### PR TITLE
Fixed PHP 8.1 compatibility type issue

### DIFF
--- a/src/FacebookAds/Object/ServerSide/AdsPixelSettings.php
+++ b/src/FacebookAds/Object/ServerSide/AdsPixelSettings.php
@@ -151,7 +151,7 @@ class AdsPixelSettings implements ArrayAccess {
    * @param integer $offset Offset
    * @return boolean
    */
-  public function offsetExists($offset) {
+  public function offsetExists($offset): bool {
     return isset($this->container[$offset]);
   }
 
@@ -160,7 +160,7 @@ class AdsPixelSettings implements ArrayAccess {
    * @param integer $offset Offset
    * @return mixed
    */
-  public function offsetGet($offset) {
+  public function offsetGet($offset): mixed {
     return isset($this->container[$offset]) ? $this->container[$offset] : null;
   }
 
@@ -170,7 +170,7 @@ class AdsPixelSettings implements ArrayAccess {
    * @param mixed $value Value to be set
    * @return void
    */
-  public function offsetSet($offset, $value) {
+  public function offsetSet($offset, $value): void {
     if (is_null($offset)) {
       $this->container[] = $value;
     } else {
@@ -183,7 +183,7 @@ class AdsPixelSettings implements ArrayAccess {
    * @param integer $offset Offset
    * @return void
    */
-  public function offsetUnset($offset) {
+  public function offsetUnset($offset): void {
     unset($this->container[$offset]);
   }
 


### PR DESCRIPTION
While upgrading the php version of a wordpress project, I got errors from the [Facebook-Pixel-for-Wordpress](https://github.com/facebookincubator/Facebook-Pixel-for-Wordpress) which has this as a dependency. 

All this does is add types to the functions to make them compatible with the latest PHP version.