### PR TITLE
Fix syntax error

### DIFF
--- a/src/FacebookAds/Object/ServerSide/EventRequest.php
+++ b/src/FacebookAds/Object/ServerSide/EventRequest.php
@@ -241,7 +241,7 @@ class EventRequest implements ArrayAccess {
 
     } else if ($this->endpoint_request != null) {
         $capiResponse = $this->sendToCAPIEndpoint();
-        $capiResponse->setCustomEndpointResponses(array($this->endpoint_request->getEndpoint() => $this->sendEventsToCustomEndpoint());
+        $capiResponse->setCustomEndpointResponses(array($this->endpoint_request->getEndpoint() => $this->sendEventsToCustomEndpoint()));
         return $capiResponse;
     }
     return $this->sendToCAPIEndpoint();


### PR DESCRIPTION
The v15 tag has a syntax error, making the release unusable. This fixes the error.

@stcheng as mentioned in a previous PR, `src/FacebookAds/Object/ServerSide` does not appear in <https://github.com/facebook/facebook-business-sdk-codegen/tree/main/templates/php/src/FacebookAds/Object>. So if there is another place we should be updating this, please let me know.