### PR TITLE
Update Normalizer.php

### DIFF
--- a/src/FacebookAds/Object/ServerSide/Normalizer.php
+++ b/src/FacebookAds/Object/ServerSide/Normalizer.php
@@ -39,6 +39,11 @@ class Normalizer {
    * @return string
    */
   public static function normalize($field, $data) {
+    
+    if (is_array($data)) {
+        $data = $data[0];
+    }
+    
     if ($data == null || strlen($data) == 0) {
       return null;
     }


### PR DESCRIPTION
Fix to avoid PHP Warning that breaks PHP8. In some circumstances data is sent as an array, but this method expects string.