### PR TITLE
Fix: Cursor.php return type hint breaks php < 8

### DIFF
--- a/src/FacebookAds/Cursor.php
+++ b/src/FacebookAds/Cursor.php
@@ -435,10 +435,8 @@ class Cursor implements \Iterator, \Countable, \ArrayAccess {
     $this->position = $position;
   }
 
-  public function current() : AbstractObject|bool {
-    return isset($this->objects[$this->position])
-      ? $this->objects[$this->position]
-      : false;
+  public function current() : ?AbstractObject {
+    return $this->objects[$this->position] ?? null;
   }
 
   public function key() : ?int {


### PR DESCRIPTION
Fixes issue introduced in versions > 15.0.2
when current() function doc line: "* @return AbstractObject|bool" was changed by return type hint: "public function current() : AbstractObject|bool {"

Changed current() return typing from AbstractObject|bool to AbstractObject|null to better match what you would expect