### PR TITLE
Adding default state to exception status code

### DIFF
--- a/src/FacebookAds/Http/Exception/RequestException.php
+++ b/src/FacebookAds/Http/Exception/RequestException.php
@@ -87,7 +87,7 @@ class RequestException extends Exception {
     $this->response = $response;
     $error_data = static::getErrorData($response);
 
-    parent::__construct($error_data['message'], $error_data['code']);
+    parent::__construct($error_data['message'], $error_data['code'] ?? 0);
 
     $this->errorSubcode = $error_data['error_subcode'];
     $this->errorUserTitle = $error_data['error_user_title'];


### PR DESCRIPTION
Issue Title: Passing null to parameter #2 ($code) of type int is deprecated
Issue Description: 
Problem location -> "facebook/php-business-sdk/src/FacebookAds/Http/Exception/RequestException.php(90): Tracy\DevelopmentStrategy::handleError" 
Exception -> Passing null to parameter #2 ($code) of type int is deprecated

Debugging Data:
Kernel version -> Linux klarka9.stable.cz 3.10.0-1160.66.1.el7.x86_64 #1 SMP Wed May 18 16:02:34 UTC 2022 x86_64
Runtime -> PHP 8.1.18

Stack Trace -> [ErrorException: Exception::__construct(): Passing null to parameter #2 ($code) of type int is deprecated
x27 /vendor/facebook/php-business-sdk/src/FacebookAds/Http/Exception/RequestException.php(90): Tracy\DevelopmentStrategy::handleError
x26 /vendor/tracy/tracy/src/Tracy/Debugger/Debugger.php(358): Tracy\Debugger::errorHandler
x25 [internal](0): call_user_func_array
x24 /vendor/facebook/php-business-sdk/src/FacebookAds/CrashReporter.php(154): FacebookAds\CrashReporter::FacebookAds\{closure}
x23 [internal](0): Exception::__construct
x22 /vendor/facebook/php-business-sdk/src/FacebookAds/Http/Exception/RequestException.php(90): FacebookAds\Http\Exception\RequestException::__construct
x21 /vendor/facebook/php-business-sdk/src/FacebookAds/Http/Exception/EmptyResponseException.php(40): FacebookAds\Http\Exception\EmptyResponseException::__construct
x20 /vendor/facebook/php-business-sdk/src/FacebookAds/Http/Client.php(220): FacebookAds\Http\Client::sendRequest
x19 /vendor/facebook/php-business-sdk/src/FacebookAds/Http/Request.php(286): FacebookAds\Http\Request::execute
x18 /vendor/facebook/php-business-sdk/src/FacebookAds/Api.php(165): FacebookAds\Api::executeRequest
x17 /vendor/facebook/php-business-sdk/src/FacebookAds/Api.php(214): FacebookAds\Api::call
x16 /vendor/facebook/php-business-sdk/src/FacebookAds/ApiRequest.php(187): FacebookAds\ApiRequest::execute]
