### PR TITLE
Update AppData.php to keep application_tracking_enabled and advertiser_tracking_enabled when they are false

### DIFF
--- a/src/FacebookAds/Object/ServerSide/AppData.php
+++ b/src/FacebookAds/Object/ServerSide/AppData.php
@@ -285,9 +285,7 @@ class AppData implements ArrayAccess {
    */
   public function normalize() {
     $normalized_payload = array();
-
-    $normalized_payload['application_tracking_enabled'] = $this->getApplicationTrackingEnabled();
-    $normalized_payload['advertiser_tracking_enabled'] = $this->getAdvertiserTrackingEnabled();
+    
     $normalized_payload['app_user_id']= $this->getAppUserId();
     $normalized_payload['campaign_ids'] = $this->getCampaignIds();
     $normalized_payload['consider_views'] = $this->getConsiderViews();
@@ -301,6 +299,11 @@ class AppData implements ArrayAccess {
     $normalized_payload['windows_attribution_id'] = $this->getWindowsAttributionId();
 
     $normalized_payload = array_filter($normalized_payload);
+
+    // The following two booleans are set after array_filter because they are required and 
+    // shouldn't be removed when falsy
+    $normalized_payload['application_tracking_enabled'] = $this->getApplicationTrackingEnabled();
+    $normalized_payload['advertiser_tracking_enabled'] = $this->getAdvertiserTrackingEnabled();
 
     return $normalized_payload;
   }


### PR DESCRIPTION
application_tracking_enabled and advertiser_tracking_enabled are required by the api as seen here https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/app-data/. 

Due to their nature (boolean) they can be false. The array_filter was removing them when they were falsy which was causing errors on the api request because they were missing.

This pr fixes this issue by moving the required attributes bellow the array_filter.