### PR TITLE
Fix undefined function GuzzleHttp\Promise\unwrap()

### DIFF
--- a/src/FacebookAds/Object/ServerSide/BatchProcessor.php
+++ b/src/FacebookAds/Object/ServerSide/BatchProcessor.php
@@ -24,7 +24,7 @@
 
 namespace FacebookAds\Object\ServerSide;
 
-use GuzzleHttp\Promise;
+use GuzzleHttp\Promise\Utils;
 
 class BatchProcessor {
   protected $batch_size;
@@ -53,7 +53,7 @@ class BatchProcessor {
   public function processEvents($event_request_params, $events) {
     $generator = $this->processEventsGenerator($event_request_params, $events);
     foreach ($generator as $promises) {
-      Promise\unwrap($promises);
+      Utils::unwrap($promises);
     }
   }
 
@@ -94,7 +94,7 @@ class BatchProcessor {
   public function processEventRequests($event_requests_async) {
     $generator = $this->processEventRequestsGenerator($event_requests_async);
     foreach ($generator as $promises) {
-      Promise\unwrap($promises);
+      Utils::unwrap($promises);
     }
   }
 

--- a/test/FacebookAdsTest/Object/ServerSide/BatchProcessorTest.php
+++ b/test/FacebookAdsTest/Object/ServerSide/BatchProcessorTest.php
@@ -29,7 +29,7 @@ use FacebookAds\Object\ServerSide\Event;
 use FacebookAds\Object\ServerSide\UserData;
 use FacebookAds\Object\ServerSide\BatchProcessor;
 use FacebookAds\Api;
-use GuzzleHttp\Promise;
+use GuzzleHttp\Promise\Utils;
 use Mockery as m;
 
 class BatchProcessorTest extends AbstractUnitTestCase {
@@ -114,7 +114,7 @@ class BatchProcessorTest extends AbstractUnitTestCase {
     $iterations = 0;
     foreach ($generator as $promises) {
       $iterations += 1;
-      Promise\unwrap($promises);
+      Utils::unwrap($promises);
     }
 
     $this->assertEquals($iterations, 2);
@@ -158,7 +158,7 @@ class BatchProcessorTest extends AbstractUnitTestCase {
     $iterations = 0;
     foreach ($generator as $promises) {
       $iterations += 1;
-      Promise\unwrap($promises);
+      Utils::unwrap($promises);
     }
 
     $this->assertEquals(3, $iterations);


### PR DESCRIPTION
Fixing GuzzleHttp compatibility.
Function GuzzleHttp\Promise\unwrap() was removed in guzzlehttp/promises:2.0.

https://github.com/guzzle/promises/blob/1.5/src/functions.php#L157
https://github.com/guzzle/promises/blob/2.0.1/CHANGELOG.md#removed