### PR TITLE
Fix session app ID and app secret nullability

### DIFF
--- a/src/FacebookAds/Api.php
+++ b/src/FacebookAds/Api.php
@@ -61,8 +61,8 @@ class Api {
   }
 
   /**
-   * @param string $app_id
-   * @param string $app_secret
+   * @param string|null $app_id
+   * @param string|null $app_secret
    * @param string $access_token
    * @return static
    */

--- a/src/FacebookAds/CrashReporter.php
+++ b/src/FacebookAds/CrashReporter.php
@@ -74,7 +74,11 @@ class CrashReporter {
             if ($api == null) {
               self::log('Could not initialize API' . PHP_EOL);
             }
-            static::$instance = new static($api->getSession()->getAppId());
+            $appId = $api->getSession()->getAppId();
+            if ($appId == null) {
+              self::log('Missing session app ID' . PHP_EOL);
+            }
+            static::$instance = new static($appId);
             static::$instance->registerExceptionHandler();
             self::log('Enabled' . PHP_EOL);
         }

--- a/src/FacebookAds/Session.php
+++ b/src/FacebookAds/Session.php
@@ -12,12 +12,12 @@ namespace FacebookAds;
 class Session implements SessionInterface {
 
   /**
-   * @var string
+   * @var string|null
    */
   protected $appId;
 
   /**
-   * @var string
+   * @var string|null
    */
   protected $appSecret;
 
@@ -32,8 +32,8 @@ class Session implements SessionInterface {
   protected $appSecretProof;
 
   /**
-   * @param string $app_id
-   * @param string $app_secret
+   * @param string|null $app_id
+   * @param string|null $app_secret
    * @param string $access_token
    */
   public function __construct($app_id, $app_secret, $access_token) {
@@ -43,14 +43,14 @@ class Session implements SessionInterface {
   }
 
   /**
-   * @return string
+   * @return string|null
    */
   public function getAppId() {
     return $this->appId;
   }
 
   /**
-   * @return string
+   * @return string|null
    */
   public function getAppSecret() {
     return $this->appSecret;


### PR DESCRIPTION
Session app ID and app secret is nullable according to documentation examples and code usage.

https://developers.facebook.com/docs/marketing-api/conversions-api/using-the-api#send
https://github.com/facebook/facebook-php-business-sdk/blob/main/src/FacebookAds/Session.php#L70