### PR TITLE
Fix typo in readme and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
-- Graph API call upgrade to [v11.0]https://developers.facebook.com/docs/graph-api/changelog/version11.0
+- Graph API call upgrade to [v11.0](https://developers.facebook.com/docs/graph-api/changelog/version11.0)
 
 ## v10.0.1
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ $adset = $account->createAdSet(
     array(),
     array(
       AdSetFields::NAME => 'My Test AdSet',
-      AdSetFields::CAMPAIGN_ID => campaign_id,
+      AdSetFields::CAMPAIGN_ID => $campaign_id,
       AdSetFields::DAILY_BUDGET => 150,
       AdSetFields::START_TIME => (new \DateTime("+1 week"))->format(\DateTime::ISO8601),
       AdSetFields::END_TIME => (new \DateTime("+2 week"))->format(\DateTime::ISO8601),
@@ -332,7 +332,7 @@ $account->read(array('id'));
 ```
 
 When running this code, this cURL request will be printed to the console as:
-```
+```shell
 curl -G \
   -d 'fields=id' \
   -d 'access_token=<access_token>' \


### PR DESCRIPTION
## Issue [#610](https://github.com/facebook/facebook-php-business-sdk/issues/610#issue-2472108763)
Fix typo errors in [README.md](README.md) and [CHANGELOG.md](CHANGELOG.md)

## Description
#### README.md
1. **Missing Dollar Sign for Variable** ✅
In the [**Create Objects**](https://github.com/facebook/facebook-php-business-sdk/blob/main/README.md#create-objects) section, the `AdSetFields::CAMPAIGN_ID` is missing a `$` before `campaign_id`

2. **Code Block Syntax Highlighting** ✅
Add `shell` tag for [second code block line 335](https://github.com/facebook/facebook-php-business-sdk/blob/main/README.md#debug)

#### CHANGELOG.md
1. **Missing Parenthesis for Link Attachment** ✅
In the [**Unreleased v11.0.0**](https://github.com/facebook/facebook-php-business-sdk/blob/main/CHANGELOG.md#v1100), the link attached is missing a pair of parenthesis