### PR TITLE
Get Next and Previous should not use cursors

### DIFF
--- a/src/FacebookAds/Cursor.php
+++ b/src/FacebookAds/Cursor.php
@@ -274,13 +274,6 @@ class Cursor implements \Iterator, \Countable, \ArrayAccess {
       return $content['paging']['previous'];
     }
 
-    $before = $this->getBefore();
-    if ($before !== null) {
-      $request = $this->createUndirectionalizedRequest();
-      $request->getQueryParams()->offsetSet('before', $before);
-      return $request->getUrl();
-    }
-
     return null;
   }
 
@@ -291,13 +284,6 @@ class Cursor implements \Iterator, \Countable, \ArrayAccess {
     $content = $this->getLastResponse()->getContent();
     if (isset($content['paging']['next'])) {
       return $content['paging']['next'];
-    }
-
-    $after = $this->getAfter();
-    if ($after !== null) {
-      $request = $this->createUndirectionalizedRequest();
-      $request->getQueryParams()->offsetSet('after', $after);
-      return $request->getUrl();
     }
 
     return null;

--- a/test/FacebookAdsTest/CursorTest.php
+++ b/test/FacebookAdsTest/CursorTest.php
@@ -66,6 +66,8 @@ class CursorTest extends AbstractUnitTestCase {
           'after' => $this->getUniquePageId(),
           'before' => $this->getUniquePageId(),
         ),
+          'next' => $this->createUnparameterizedUrl() . '?after=' . $this->getUniquePageId(),
+          'previous' => $this->createUnparameterizedUrl() . '?before=' . $this->getUniquePageId(),
       ),
     ) + $this->createEmptyResponseContent();
 
@@ -94,8 +96,7 @@ class CursorTest extends AbstractUnitTestCase {
    * @param RequestInterface|null $prev
    * @return Mock|ResponseInterface
    */
-  protected function createResponseChainMock(
-    $num_pages, RequestInterface $prev = null) {
+  protected function createResponseChainMock($num_pages, RequestInterface $prev = null) {
 
     $query_params = $prev ? clone $prev->getQueryParams() : new Parameters();
     $sample_content = $this->createSampleResponseContent();
@@ -339,7 +340,6 @@ class CursorTest extends AbstractUnitTestCase {
     $response = $this->createResponseChainMock(3);
     $cursor = new Cursor($response, $this->objectPrototype);
 
-    $count = 0;
     while ($cursor->valid()) {
       $cursor->prev();
     }


### PR DESCRIPTION
https://developers.facebook.com/docs/graph-api/results/
- next : The Graph API endpoint that will return the next page of data. If not included, this is the last page of data. Due to how pagination works with visibility and privacy, it is possible that a page may be empty but contain a next paging link. Stop paging when the next link no longer appears.
- previous : The Graph API endpoint that will return the previous page of data. If not included, this is the first page of data.

===
For example: If my cursor has total 4 items (default limit is 25)
```
$cursor->setDefaultUseImplicitFetch(true);
foreach ($cursor as $item) {
    $data[] = $item->exportAllData();
}
```

So I need to make one request to get the cursor with 4 items. The current code  **getNext()** will always return a URL and 
```
public function fetchAfter() {
    $request = $this->createAfterRequest();
    if (!$request) {
      return;
    }

    $this->appendResponse($request->execute());
  }
```

**fetchAfter()** will **execute** one more request and return an empty data. So, we need to make 2 requests to get for only 4 items.

So if **$content['paging']['next']** is empty, we should return null and do not need to make more requests