### PR TITLE
Add missing methods to satisfy the ArrayAccess interface

### DIFF
--- a/src/FacebookAds/Object/ServerSide/AttributionData.php
+++ b/src/FacebookAds/Object/ServerSide/AttributionData.php
@@ -277,6 +277,47 @@ class AttributionData implements ArrayAccess {
     return $this->container['attr_window'];
   }
 
+  /**
+   * Returns true if offset exists. False otherwise.
+   * @param integer $offset Offset
+   * @return boolean
+   */
+  public function offsetExists($offset) : bool {
+    return isset($this->container[$offset]);
+  }
+
+  /**
+   * Gets offset.
+   * @param integer $offset Offset
+   * @return mixed
+   */
+  public function offsetGet($offset) : mixed {
+    return isset($this->container[$offset]) ? $this->container[$offset] : null;
+  }
+
+  /**
+   * Sets value based on offset.
+   * @param integer $offset Offset
+   * @param mixed $value Value to be set
+   * @return void
+   */
+  public function offsetSet($offset, $value) : void {
+    if (is_null($offset)) {
+      $this->container[] = $value;
+    } else {
+      $this->container[$offset] = $value;
+    }
+  }
+
+  /**
+   * Unsets offset.
+   * @param integer $offset Offset
+   * @return void
+   */
+  public function offsetUnset($offset) : void {
+    unset($this->container[$offset]);
+  }
+
   public function normalize() {
     $normalized_payload = array();
 


### PR DESCRIPTION
Currently, trying to create an `AttributionData` object results in this Fatal Error:
```
Class FacebookAds\Object\ServerSide\AttributionData contains 4 abstract methods and must therefore be declared abstract or implement the remaining methods (ArrayAccess::offsetExists, ArrayAccess::offsetGet, ArrayAccess::offsetSet, ...)
```

This PR aims to fix the issue.