### PR TITLE
feat: open up versions phpunit, SF finder, guzzle for Symfony 7.x and PHP 8.4+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
   "homepage": "https://developers.facebook.com/",
   "require": {
     "php": ">=8.0",
-    "guzzlehttp/guzzle": "^6.5 || ^7.0"
+    "guzzlehttp/guzzle": "^6.5 || ^7.0 || ^7.5"
   },
   "require-dev": {
-    "phpunit/phpunit": "~9",
-    "symfony/finder": "~2.6",
+    "phpunit/phpunit": "~9|^10.0",
+    "symfony/finder": "~2.6|3.0.*",
     "mockery/mockery": "1.3.3"
   },
   "autoload": {


### PR DESCRIPTION
Using [rector/jack](https://github.com/rectorphp/jack) dependency repots:

 The "phpunit/phpunit" package is outdated
 * Your version 9.6.25 is 2 weeks old
 * Bump to 12.3.8

The "symfony/finder" package is outdated
 * Your version v2.8.52 is 6 years old
 * Bump to v7.3.2

I just open up versions in require dev to next versions (this doesnt break anything, just allow to install new versions)
 
 * Opened "symfony/finder" package to "~2.6|3.0.*" version
 * Opened "phpunit/phpunit" package to "~9|^10.0" version

Also allowing a more recent version of guzzlehttp/guzzle for Symfony 7.x and others with PHP 8.4+

The current composer still allows [PHP 8.0 which is EOL](https://www.php.net/supported-versions.php), and upcoming EOL for PHP 8.1. So please for security this should be addresed for more updated versions.